### PR TITLE
Enable basic authentication

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -91,6 +91,10 @@ ExpiresDefault "access 2 days"
 # BEGIN WordPress
 <IfModule mod_rewrite.c>
 RewriteEngine On
+
+# allow Authorization header for basic auth
+RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+
 RewriteBase /
 RewriteRule ^index\.php$ - [L]
 

--- a/wp-content/plugins/basic-auth/README.md
+++ b/wp-content/plugins/basic-auth/README.md
@@ -1,0 +1,47 @@
+# Basic Authentication handler
+This plugin adds Basic Authentication to a WordPress site.
+
+Note that this plugin requires sending your username and password with every
+request, and should only be used over SSL-secured connections or for local
+development and testing. Without SSL we strongly recommend using the
+[OAuth 1.0a][oauth] authentication handler in production environments.
+
+## Installing
+1. Download the plugin into your plugins directory
+2. Enable in the WordPress admin
+
+## Using
+This plugin adds support for Basic Authentication, as specified in [RFC2617][].
+Most HTTP clients will allow you to use this authentication natively. Some
+examples are listed below.
+
+### cURL
+
+```sh
+curl --user admin:password https://example.com/wp-json/
+```
+
+### WP_Http
+
+```php
+$args = array(
+	'headers' => array(
+		'Authorization' => 'Basic ' . base64_encode( $username . ':' . $password ),
+	),
+);
+```
+
+### [node-wpapi][]
+
+```js
+const WPAPI = require('./wpapi')
+const wp = new WPAPI({
+    endpoint: 'https://example.com/wp-json',
+    username: 'editor',
+    password: 'password'
+});
+```
+
+[oauth]: https://github.com/WP-API/OAuth1
+[RFC2617]: https://tools.ietf.org/html/rfc2617
+[node-wpapi]: http://wp-api.org/node-wpapi/

--- a/wp-content/plugins/basic-auth/basic-auth.php
+++ b/wp-content/plugins/basic-auth/basic-auth.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Plugin Name: JSON Basic Authentication
+ * Description: Basic Authentication handler for the JSON API, used for development and debugging purposes
+ * Author: WordPress API Team
+ * Author URI: https://github.com/WP-API
+ * Version: 0.1
+ * Plugin URI: https://github.com/WP-API/Basic-Auth
+ */
+
+function json_basic_auth_handler( $user ) {
+	global $wp_json_basic_auth_error;
+
+	$wp_json_basic_auth_error = null;
+
+	// Don't authenticate twice
+	if ( ! empty( $user ) ) {
+		return $user;
+	}
+
+	// Check that we're trying to authenticate
+	if ( !isset( $_SERVER['PHP_AUTH_USER'] ) ) {
+		return $user;
+	}
+
+	$username = $_SERVER['PHP_AUTH_USER'];
+	$password = $_SERVER['PHP_AUTH_PW'];
+
+	/**
+	 * In multi-site, wp_authenticate_spam_check filter is run on authentication. This filter calls
+	 * get_currentuserinfo which in turn calls the determine_current_user filter. This leads to infinite
+	 * recursion and a stack overflow unless the current function is removed from the determine_current_user
+	 * filter during authentication.
+	 */
+	remove_filter( 'determine_current_user', 'json_basic_auth_handler', 20 );
+
+	$user = wp_authenticate( $username, $password );
+
+	add_filter( 'determine_current_user', 'json_basic_auth_handler', 20 );
+
+	if ( is_wp_error( $user ) ) {
+		$wp_json_basic_auth_error = $user;
+		return null;
+	}
+
+	$wp_json_basic_auth_error = true;
+
+	return $user->ID;
+}
+add_filter( 'determine_current_user', 'json_basic_auth_handler', 20 );
+
+function json_basic_auth_error( $error ) {
+	// Passthrough other errors
+	if ( ! empty( $error ) ) {
+		return $error;
+	}
+
+	global $wp_json_basic_auth_error;
+
+	return $wp_json_basic_auth_error;
+}
+add_filter( 'rest_authentication_errors', 'json_basic_auth_error' );

--- a/wp-content/plugins/basic-auth/composer.json
+++ b/wp-content/plugins/basic-auth/composer.json
@@ -1,0 +1,5 @@
+{
+	"name" : "wp-api/basic-auth",
+	"description" : "Basic Authentication handler for the JSON API, used for development and debugging purposes",
+	"type" : "wordpress-plugin"
+}


### PR DESCRIPTION
Enable basic authentification for the API.  
Using https://github.com/WP-API/Basic-Auth plugin.  Basic auth is not the most (actually close to the least) secure way for authentication but we discussed this and accepted the risks involved.  

Htaccess edit is required to allow the Authorization header to go through. See https://github.com/WP-API/Basic-Auth/issues/35#issuecomment-244001216